### PR TITLE
drop complicated logic of caching commands and events

### DIFF
--- a/implementation/src/main/scala/dev/rudiments/hardcore/flow/Controlled.scala
+++ b/implementation/src/main/scala/dev/rudiments/hardcore/flow/Controlled.scala
@@ -5,30 +5,9 @@ import dev.rudiments.hardcore.{Command, Event, Result, Skill}
 
 class Controlled[E <: Event](skill: Skill[E])(implicit flow: ControlFlow) extends Skill[E] {
 
-  override def isDefinedAt(cmd: Command): Boolean = cmd match {
-    case c: Command if skill.isDefinedAt(c) => true
-    case _: ControlCommand => false //for future use
-    case other => false
-  }
+  override def isDefinedAt(cmd: Command): Boolean = skill.isDefinedAt(cmd)
 
-  override def apply(cmd: Command): Result[E] = cmd match {
-    case c: AlwaysDo => execute(c)
-    case c: BulkRead => execute(c)
-    case c: SideEffect => execute(c) //TODO think!
-    case c: CacheSingle =>
-      flow.cachedContext.get(c.key) match {
-        case Some((command, nested: Command)) if command == cmd => this(nested)
-        case Some((command, event: Event)) if command == cmd => event.toEither
-        case Some((command, other)) if command != cmd => execute(cmd)
-        case None => execute(c)
-      }
-    case c: Command =>
-      flow.lastMessage(c) match { //TODO wrong?
-        case Some(command: Command) => this(command)
-        case Some(evt: Event) => evt.toEither
-        case None => execute(cmd)
-      }
-  }
+  override def apply(cmd: Command): Result[E] = execute(cmd)
 
   private def execute(cmd: Command): Result[E] = {
     cmd match {

--- a/todo-example-app/todo.http
+++ b/todo-example-app/todo.http
@@ -20,6 +20,18 @@ Content-Type: application/json
 
 ###
 
+PUT http://localhost:8080/todo/4
+Content-Type: application/json
+
+{
+  "id": 4,
+  "name": "TODO Item #4",
+  "done": false,
+  "comment": "comment"
+}
+
+###
+
 POST http://localhost:8080/todo/4/done
 
 ###


### PR DESCRIPTION
Дропнул замудреную логику кэширования, теперь ControlFlow не влияет на выполнение команд и только запоминает что происходило.

Добавил пример запроса PUT и погонял его вручную.