### PR TITLE
GH-71 add codecov.io report generation and upload steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hard Core
 
 [![Build Status](https://dev.azure.com/rudiments-dev/hardcore/_apis/build/status/rudiments-dev.hardcore?branchName=master&jobName=Run%20unit%20testing%20with%20gradlew)](https://dev.azure.com/rudiments-dev/hardcore/_build/latest?definitionId=2&branchName=master)
+[![codecov](https://codecov.io/gh/rudiments-dev/hardcore/branch/develop/graph/badge.svg)](https://codecov.io/gh/rudiments-dev/hardcore)
 [![Maven Central](https://img.shields.io/maven-central/v/dev.rudiments/implementation.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22dev.rudiments%22%20AND%20a:%22implementation%22)
 
 Research project and bootstrap library.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,10 @@ jobs:
     condition: eq('${{ parameters.release }}', false)
     steps:
       - script: |
-          ./gradlew build
+          ./gradlew build aggregateScoverage
+           bash <(curl -s https://codecov.io/bash)
+        displayName: 'Run unit testing with gradlew'
+
 
   - job: push_snapshots
     displayName: 'Push latest Rudiments snapshots to Maven Snapshots repo'

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,20 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2"
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
+        classpath 'gradle.plugin.org.scoverage:gradle-scoverage:4.0.2'
     }
 }
 
 allprojects {
+    apply plugin: 'org.scoverage'
+
     group 'dev.rudiments'
     version '0.3-SNAPSHOT'
 


### PR DESCRIPTION
Проверка существующих инструментов генерации отчетов покрытия кода тестами:

- codecov.io
- coveralls.io